### PR TITLE
Add missing description of the path argument

### DIFF
--- a/magali/_io.py
+++ b/magali/_io.py
@@ -14,7 +14,6 @@ import verde as vd
 
 from ._constants import METER_TO_MICROMETER, TESLA_TO_NANOTESLA
 
-
 def read_qdm_harvard(path):
     """
     Load QDM microscopy data in the Harvard group format.
@@ -26,12 +25,12 @@ def read_qdm_harvard(path):
     Parameters
     ----------
     path : str or pathlib.Path
+        Path to the input Matlab binary file.
 
     Returns
     -------
     data : xarray.Dataset
-        The magnetic field data as a regular grid with coordinates. The
-        coordinates are in µm and magnetic field in nT.
+        The magnetic field data as a regular grid with coordinates. The coordinates are in µm and magnetic field in nT.
     """
     contents = scipy.io.loadmat(path)
     # For some reason, the spacing is returned as an array with a single

--- a/magali/_io.py
+++ b/magali/_io.py
@@ -14,6 +14,7 @@ import verde as vd
 
 from ._constants import METER_TO_MICROMETER, TESLA_TO_NANOTESLA
 
+
 def read_qdm_harvard(path):
     """
     Load QDM microscopy data in the Harvard group format.
@@ -30,7 +31,8 @@ def read_qdm_harvard(path):
     Returns
     -------
     data : xarray.Dataset
-        The magnetic field data as a regular grid with coordinates. The coordinates are in µm and magnetic field in nT.
+        The magnetic field data as a regular grid with coordinates. The
+        coordinates are in µm and magnetic field in nT.
     """
     contents = scipy.io.loadmat(path)
     # For some reason, the spacing is returned as an array with a single


### PR DESCRIPTION
The read_qdm_harvard docstring was missing description of an argument.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
