### PR TITLE
Fix version bounds for Choclo dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "xarray>=2022.6.0",
     "harmonica>=0.6",
     "verde>=1.8.1",
-    "choclo==0.2.0",
+    "choclo>=0.2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Was pinning to v0.2.0 but we don't need to pin anymore and can set it as a lower bound. Version 0.2 reintroduced a function that we needed from v0.0.1 and will retain going forward.