### PR TITLE
Replace `build` for `python-build` in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - harmonica
   - verde
   # Build
-  - build
+  - python-build
   - twine
   # Test
   - pooch


### PR DESCRIPTION
The `build` package in `conda-forge` is outdated, `python-build` should be used instead.
