### PR TITLE
Modify read_qdm_harvard to return DataArray Instead of DataFrame

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -36,4 +36,8 @@ Load some data:
 
 .. jupyter-execute::
 
-    data.bz.plot(cmap="RdBu_r", vmin=-1000, vmax=1000)
+    fig, ax = plt.subplots(1, 1, figsize=(9, 4.8), layout="constrained")
+    scale = 2500
+    data.plot.imshow(ax=ax, cmap="RdBu_r", vmin=-scale, vmax=scale)
+    ax.set_aspect("equal")
+    plt.show()

--- a/magali/_input_output.py
+++ b/magali/_input_output.py
@@ -19,20 +19,22 @@ def read_qdm_harvard(path):
     """
     Load QDM microscopy data in the Harvard group format.
 
-    This is the file type used by Roger Fu's group to distribute QDM data. It's
-    a Matlab binary file that has the data and some information about grid
-    spacing.
+    This function loads quantum diamond microscope (QDM) data stored in the
+    Matlab binary format used by Roger Fu's research group at Harvard.
+    The file contains magnetic field measurements and metadata, including
+    grid spacing information.
 
     Parameters
     ----------
     path : str or pathlib.Path
-        Path to the input Matlab binary file.
+        Path to the input Matlab (.mat) file.
 
     Returns
     -------
-    data : xarray.Dataset
-        The magnetic field data as a regular grid with coordinates. The
-        coordinates are in µm and magnetic field in nT.
+    data.bz : xarray.DataArray
+        A 2D array representing the magnetic field component (Bz) on a
+        regular grid. The coordinates are in micrometers (µm), and the
+        magnetic field values are in nanotesla (nT).
     """
     contents = scipy.io.loadmat(path)
     coordinates, data_names, bz = _extract_data_qdm_harvard(contents)

--- a/magali/_input_output.py
+++ b/magali/_input_output.py
@@ -37,7 +37,7 @@ def read_qdm_harvard(path):
     contents = scipy.io.loadmat(path)
     coordinates, data_names, bz = _extract_data_qdm_harvard(contents)
     data = _create_qdm_harvard_grid(coordinates, data_names, bz, path)
-    return data
+    return data.bz
 
 
 def _extract_data_qdm_harvard(contents):

--- a/magali/tests/test_io.py
+++ b/magali/tests/test_io.py
@@ -19,5 +19,5 @@ def test_read_qdm_harvard():
         "doi:10.6084/m9.figshare.22965200.v1/Bz_uc0.mat",
         known_hash="md5:268bd3af5e350188d239ff8bd0a88227",
     )
-    data = read_qdm_harvard(path)
-    assert data.bz.size == 576_000
+    bz = read_qdm_harvard(path)
+    assert bz.size == 576_000


### PR DESCRIPTION
This PR updates read_qdm_harvard to return an DataArray instead of a DataFrame. Additionally, it updates the QDM data plot on the overview page of the documentation.

## Changes

* Modified read_qdm_harvard to return an DataArray.
* Updated the overview page's QDM data bz plot to work with DataArray.
* Adjusted axis labels and color scale for better readability.

**Relevant issues/PRs:**
Related to #45 
Fixes #40 
