### PR TITLE
Fix Yago Moreira Castro's name

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,6 +3,6 @@
 The following people have made contributions to the project (in alphabetical
 order by last name) and are considered "The Magali developers":
 
-* [Yago Castro](https://github.com/YagoMCastro) - Universidade de São Paulo, Brazil (ORCID: 0009-0003-3884-9675)
+* [Yago Moreira Castro](https://github.com/YagoMCastro) - Universidade de São Paulo, Brazil (ORCID: 0009-0003-3884-9675)
 * [Gelson Ferreira](https://github.com/Souza-junior) - Universidade de São Paulo, Brazil (ORCID: 0000-0002-5695-4239)
 * [Leonardo Uieda](https://github.com/leouieda) - Universidade de São Paulo, Brazil (ORCID: 0000-0001-6123-9515)


### PR DESCRIPTION
Yago's first surname was not included.
