### PR TITLE
Use Ensaio instead of Pooch to retrieve QDM data

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -14,7 +14,7 @@ single import:
     # magali is usually imported as mg
     import magali as mg
 
-    import pooch
+    import ensaio
     import matplotlib.pyplot as plt
 
 
@@ -22,15 +22,13 @@ Load some data:
 
 .. jupyter-execute::
 
-    path = pooch.retrieve(
-        "doi:10.6084/m9.figshare.22965200.v1/Bz_uc0.mat",
-        known_hash="md5:268bd3af5e350188d239ff8bd0a88227",
-    )
-    print(path)
+
+    fname = ensaio.fetch_morroco_speleothem_qdm(version=1, file_format="matlab")
+    print(fname)
 
 .. jupyter-execute::
 
-    data = mg.read_qdm_harvard(path)
+    data = mg.read_qdm_harvard(fname)
     data
 
 .. jupyter-execute::

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -15,7 +15,7 @@ single import:
     # magali is usually imported as mg
     import magali as mg
 
-    import pooch
+    import ensaio
     import matplotlib.pyplot as plt
 
 
@@ -23,21 +23,15 @@ Load some data:
 
 .. jupyter-execute::
 
-    path = pooch.retrieve(
-        "doi:10.6084/m9.figshare.22965200.v1/Bz_uc0.mat",
-        known_hash="md5:268bd3af5e350188d239ff8bd0a88227",
-    )
-    print(path)
+    fname = ensaio.fetch_morroco_speleothem_qdm(version=1, file_format="netcdf")
+    print(fname)
 
 .. jupyter-execute::
 
-    data = mg.read_qdm_harvard(path)
+    data = mg.read_qdm_harvard(fname)
     data
 
 .. jupyter-execute::
 
-    fig, ax = plt.subplots(1, 1, figsize=(9, 4.8), layout="constrained")
-    scale = 2500
-    data.plot.imshow(ax=ax, cmap="RdBu_r", vmin=-scale, vmax=scale)
-    ax.set_aspect("equal")
-    plt.show()
+    data.bz.plot(cmap="RdBu_r", vmin=-1000, vmax=1000)
+

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -5,9 +5,8 @@ Overview
 
 The library
 -----------
-
-All functionality in magali is available from the base namespace of the
-:mod:`magali` package. This means that you can access all of them with a
+All functionality in magali is available from the base namespace of the 
+:mod:`magali` package. This means that you can access all of them with a 
 single import:
 
 .. jupyter-execute::
@@ -15,7 +14,7 @@ single import:
     # magali is usually imported as mg
     import magali as mg
 
-    import ensaio
+    import pooch
     import matplotlib.pyplot as plt
 
 
@@ -23,15 +22,21 @@ Load some data:
 
 .. jupyter-execute::
 
-    fname = ensaio.fetch_morroco_speleothem_qdm(version=1, file_format="netcdf")
-    print(fname)
+    path = pooch.retrieve(
+        "doi:10.6084/m9.figshare.22965200.v1/Bz_uc0.mat",
+        known_hash="md5:268bd3af5e350188d239ff8bd0a88227",
+    )
+    print(path)
 
 .. jupyter-execute::
 
-    data = mg.read_qdm_harvard(fname)
+    data = mg.read_qdm_harvard(path)
     data
 
 .. jupyter-execute::
 
-    data.bz.plot(cmap="RdBu_r", vmin=-1000, vmax=1000)
-
+    fig, ax = plt.subplots(1, 1, figsize=(9, 4.8), layout="constrained")
+    scale = 2500
+    data.plot.imshow(ax=ax, cmap="RdBu_r", vmin=-scale, vmax=scale)
+    ax.set_aspect("equal")
+    plt.show()

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - choclo
   - harmonica
   - verde
+  - ensaio
   # Build
   - python-build
   - twine

--- a/magali/tests/test_io.py
+++ b/magali/tests/test_io.py
@@ -8,16 +8,13 @@
 Test the IO functions
 """
 
-import pooch
+import ensaio
 
 from .._input_output import read_qdm_harvard
 
 
 def test_read_qdm_harvard():
     "Try loading a sample dataset"
-    path = pooch.retrieve(
-        "doi:10.6084/m9.figshare.22965200.v1/Bz_uc0.mat",
-        known_hash="md5:268bd3af5e350188d239ff8bd0a88227",
-    )
-    bz = read_qdm_harvard(path)
+    fname = ensaio.fetch_morroco_speleothem_qdm(version=1, file_format="netcdf")
+    bz = read_qdm_harvard(fname)
     assert bz.size == 576_000

--- a/magali/tests/test_io.py
+++ b/magali/tests/test_io.py
@@ -15,6 +15,6 @@ from .._input_output import read_qdm_harvard
 
 def test_read_qdm_harvard():
     "Try loading a sample dataset"
-    fname = ensaio.fetch_morroco_speleothem_qdm(version=1, file_format="netcdf")
+    fname = ensaio.fetch_morroco_speleothem_qdm(version=1, file_format="matlab")
     bz = read_qdm_harvard(fname)
     assert bz.size == 576_000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "harmonica>=0.7",
     "verde>=1.8.1",
     "choclo>=0.2.0",
+    "ensaio>=0.7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR updates the data retrieval process for QDM data by replacing  `Pooch` with `Ensaio` on tests and documentation. 
`Ensaio` offers better data version control through dataset tracking, while also simplifying the tutorial on the documentation by the abstraction of a few arguments that `Pooch` would require.

### Changes  
- Replaces `pooch.retrieve` calls with `ensaio.fetch`  
- Updates documentation and references to reflect the use of Ensaio 
- Add `Ensaio` to `pyproject.toml` and `environment.yml`
- Update QDM data plot on overview documentation page

**Relevant issues/PRs:**
Related to #35 
Related to #45 