### PR TITLE
Update Harmonica 0.7.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - xarray
   - scikit-image
   - choclo
-  - harmonica
+  - harmonica==0.7.0
   - verde
   - ensaio
   # Build


### PR DESCRIPTION
Magali depends on the functions `magnetic_vec_to_angles` and `magnetic_angles_to_vec`, which are only available from Harmonica 0.7.0. These functions will be needed for the making of forward modelling tools.

**Relevant issues/PRs:**
Related to #13 
Related to #54 