### PR TITLE
Remove self.jacobian from MagneticMomentBz

### DIFF
--- a/magali/_inversion.py
+++ b/magali/_inversion.py
@@ -50,7 +50,6 @@ class MagneticMomentBz:
     def __init__(self, location):
         self.location = location
         self.dipole_moment_ = None
-        self.jacobian = None
 
     def _calculate_jacobian(self, x, y, z):
         """
@@ -111,7 +110,6 @@ class MagneticMomentBz:
         data = np.ravel(np.asarray(data * 1e-9))
 
         jacobian = self._calculate_jacobian(x, y, z)
-        self.jacobian = jacobian
         hessian = jacobian.T @ jacobian
         hessian_inv = np.linalg.inv(hessian)
         estimate = hessian_inv @ jacobian.T @ data

--- a/magali/tests/test_inversion.py
+++ b/magali/tests/test_inversion.py
@@ -60,7 +60,6 @@ def test_MagneticMomentBz():
     # Test initalization
     assert model.location == dipole_coordinates
     assert model.dipole_moment_ is None
-    assert model.jacobian is None
 
     model.fit(coordinates, data)
     dipole_moment = np.array(
@@ -69,6 +68,4 @@ def test_MagneticMomentBz():
 
     # Assert estimated moment is close to true moment
     assert model.dipole_moment_ is not None
-    assert model.jacobian is not None
-    assert model.jacobian.shape == (coordinates[0].size, 3)
     np.testing.assert_allclose(model.dipole_moment_, dipole_moment, rtol=1e2)


### PR DESCRIPTION
The `MagneticMomentBz` class currently contains the `self.jacobian` attribute, which is not only unnecessary for the functionality of the class but also excessively large.