### PR TITLE
Remove the constants from the API

### DIFF
--- a/magali/__init__.py
+++ b/magali/__init__.py
@@ -4,7 +4,6 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-from ._constants import METER_TO_MICROMETER, MICROMETER_TO_METER, TESLA_TO_NANOTESLA
 from ._detection import detect_anomalies
 from ._input_output import read_qdm_harvard
 from ._inversion import MagneticMomentBz


### PR DESCRIPTION
The constants are imported in `__init__.py` but we don't want them as part of the official API. They are meant for internal use only. They aren't actually listed in the API docs so I only removed them from the `__init__.py`.