### PR TITLE
Refactor Actions to use more caching and lint them

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,16 @@ on:
     types:
       - published
 
+permissions: {}
+
 # Use bash by default in all jobs
 defaults:
   run:
     # The -l {0} is necessary for conda environments to be activated
     # But this breaks on MacOS if using actions/setup-python:
     # https://github.com/actions/setup-python/issues/132
-    shell: bash -l {0}
+    # -e makes sure builds fail if any command fails
+    shell: bash -e -l {0}
 
 jobs:
   #############################################################################
@@ -76,6 +79,16 @@ jobs:
           echo "Collected dependencies:"
           cat requirements-full.txt
 
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-full.txt') }}
+
       - name: Install requirements
         run: python -m pip install --requirement requirements-full.txt
 
@@ -83,21 +96,20 @@ jobs:
         run: python -m pip freeze
 
       - name: Build source and wheel distributions
-        run: |
-          make build
-          echo ""
-          echo "Generated files:"
-          ls -lh dist/
+        run: make build
 
       - name: Install the package
         run: pip install --no-deps dist/*.whl
 
-      - name: Cache the downloaded datasets
+      - name: Get the version of ensaio
+        id: ensaio-version
+        run: echo "v=$(grep ensaio env/requirements-docs.txt)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching of Ensaio datasets
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}/.cache/pooch
-          # Use a constant key to reuse the datasets across all jobs
-          key: pooch
+          path: ${{ runner.temp }}/cache/ensaio
+          key: ensaio-data-${{ steps.ensaio-version.outputs.v }}
 
       - name: Build the documentation
         run: make -C doc clean all
@@ -119,6 +131,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
 
       # Fetch the built docs from the "build" job
       - name: Download HTML documentation artifact
@@ -135,6 +151,9 @@ jobs:
           path: deploy
           # Download the entire history
           fetch-depth: 0
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
 
       - name: Push the built HTML to gh-pages
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,6 +16,8 @@ on:
     types:
       - published
 
+permissions: {}
+
 # Use bash by default in all jobs
 defaults:
   run:
@@ -106,7 +108,7 @@ jobs:
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
         if: success() && github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
@@ -116,4 +118,4 @@ jobs:
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
         if: success() && github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,9 +14,12 @@ on:
     branches:
       - main
 
+permissions: {}
+
 ###############################################################################
 jobs:
-  format:
+  check:
+    name: check style and format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,7 +30,17 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
+
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('env/requirements-style.txt') }}
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt
@@ -35,27 +48,5 @@ jobs:
       - name: List installed packages
         run: python -m pip freeze
 
-      - name: Check code format
-        run: make check-format
-
-  style:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install requirements
-        run: python -m pip install -r env/requirements-style.txt
-
-      - name: List installed packages
-        run: python -m pip freeze
-
-      - name: Check code style
-        run: make check-style
+      - name: Check code style and format
+        run: make check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,16 @@ on:
     types:
       - published
 
+permissions: {}
+
 # Use bash by default in all jobs
 defaults:
   run:
-    # Using "-l {0}" is necessary for conda environments to be activated
+    # The -l {0} is necessary for conda environments to be activated
     # But this breaks on MacOS if using actions/setup-python:
     # https://github.com/actions/setup-python/issues/132
-    shell: bash
+    # -e makes sure builds fail if any command fails
+    shell: bash -e -o pipefail -l {0}
 
 jobs:
 
@@ -32,24 +35,19 @@ jobs:
   # Run tests
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
-        os:
-          - ubuntu
-          - macos
-          - windows
-        dependencies:
-          - oldest
-          - latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.9", "3.12"]
         include:
-          - dependencies: oldest
-            python: "3.9"
-          - dependencies: latest
-            python: "3.12"
+          - python: "3.9"
+            dependencies: oldest
+          - python: "3.12"
+            dependencies: latest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions
@@ -129,6 +127,16 @@ jobs:
       - name: Install the package
         run: python -m pip install --no-deps dist/*.whl
 
+      - name: Get the version of ensaio
+        id: ensaio-version
+        run: echo "v=$(grep ensaio env/requirements-docs.txt)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching of Ensaio datasets
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/cache/ensaio
+          key: ensaio-data-${{ steps.ensaio-version.outputs.v }}
+
       - name: Run the tests
         run: make test
 
@@ -163,7 +171,7 @@ jobs:
         run: ls -l -R .
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
         with:
           # Upload all coverage report files
           files: ./coverage_*/coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PROJECT=magali
 TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
 CHECK_STYLE=$(PROJECT) doc
+GITHUB_ACTIONS=.github/workflows
 
 help:
 	@echo "Commands:"
@@ -33,7 +34,7 @@ format:
 	ruff format $(CHECK_STYLE)
 	burocrata --extension=py $(CHECK_STYLE)
 
-check: check-format check-style
+check: check-format check-style check-actions
 
 check-format:
 	ruff format --check $(CHECK_STYLE)
@@ -41,6 +42,9 @@ check-format:
 
 check-style:
 	ruff format --check $(CHECK_STYLE)
+
+check-actions:
+	zizmor $(GITHUB_ACTIONS)
 
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;

--- a/env/requirements-style.txt
+++ b/env/requirements-style.txt
@@ -1,3 +1,4 @@
 # Requirements for checking code style and format
 ruff
 burocrata
+zizmor

--- a/environment.yml
+++ b/environment.yml
@@ -31,5 +31,6 @@ dependencies:
   - matplotlib
   # Style
   - ruff
+  - zizmor
   - pip:
     - burocrata


### PR DESCRIPTION
Use zizmor to lint the GitHub Actions workflows. Fix some of the issues it brought up, like pinning third-party actions to commits instead of version tags. Make use of caching of pip packages and Ensaio data downloads to minimize traffic and build times. Combine all style checks into a single job to avoid the overhead of setting up a virtual machine.