### PR TITLE
Rename "gradients" to "gradient"

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -15,7 +15,7 @@ List of functions and classes (API)
    random_directions
    dipole_bz
    dipole_bz_grid
-   gradients
+   gradient
    total_gradient_amplitude
    total_gradient_amplitude_grid
    detect_anomalies

--- a/magali/__init__.py
+++ b/magali/__init__.py
@@ -10,7 +10,7 @@ from ._input_output import read_qdm_harvard
 from ._inversion import MagneticMomentBz
 from ._synthetic import dipole_bz, dipole_bz_grid, random_directions
 from ._utils import (
-    gradients,
+    gradient,
     total_gradient_amplitude,
     total_gradient_amplitude_grid,
 )

--- a/magali/_utils.py
+++ b/magali/_utils.py
@@ -45,7 +45,7 @@ def _estimate_grid_spacing(data):
     return np.mean([np.abs(data.x[1] - data.x[0]), np.abs(data.y[1] - data.y[0])])
 
 
-def gradients(data):
+def gradient(data):
     """
     Compute first-order spatial derivatives in the x, y, and z directions.
 
@@ -122,7 +122,7 @@ def total_gradient_amplitude_grid(data):
     tga : xr.DataArray
         Dataset containing the total gradient amplitude (TGA).
     """
-    dx, dy, dz = gradients(data)
+    dx, dy, dz = gradient(data)
     tga = total_gradient_amplitude(dx, dy, dz)
 
     # Assign attributes

--- a/magali/tests/test_utils.py
+++ b/magali/tests/test_utils.py
@@ -15,7 +15,7 @@ import xarray as xr
 from .._utils import (
     _convert_micrometer_to_meter,
     _estimate_grid_spacing,
-    gradients,
+    gradient,
     total_gradient_amplitude,
     total_gradient_amplitude_grid,
 )
@@ -41,9 +41,9 @@ def test_estimate_grid_spacing(souza_junior_model):
     assert spacing == 2.0
 
 
-def test_gradients(souza_junior_model):
+def test_gradient(souza_junior_model):
     # Use model fixture from _models.py
-    dx, dy, dz = gradients(souza_junior_model)
+    dx, dy, dz = gradient(souza_junior_model)
 
     np.testing.assert_allclose(dx.min().values, -92762.44269656, rtol=1e2)
     np.testing.assert_allclose(dy.min().values, -88701.89017599083, rtol=1e2)
@@ -62,7 +62,7 @@ def test_total_gradient_amplitude(souza_junior_model):
     # Use model fixture from _models.py
     data = souza_junior_model
 
-    dx, dy, dz = gradients(data)
+    dx, dy, dz = gradient(data)
 
     tga = total_gradient_amplitude(dx, dy, dz)
 


### PR DESCRIPTION
It's singular because this function calculates the gradient vector. It's a single vector, not multiple ones. It could also be called "derivatives" but the gradient is only one.