### PR TITLE
Cache Ensaio data on CI and fetch from GitHub

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -101,8 +101,23 @@ jobs:
       - name: Install the package
         run: pip install --no-deps dist/*.whl
 
+      - name: Get the version of ensaio
+        id: ensaio-version
+        run: echo "v=$(grep ensaio env/requirements-docs.txt)" >> $GITHUB_OUTPUT
+
+      - name: Setup caching of Ensaio datasets
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/cache/ensaio
+          key: ensaio-data-${{ steps.ensaio-version.outputs.v }}
+
       - name: Build the documentation
         run: make -C doc clean all
+        env:
+          # Define directory where sample data will be stored
+          ENSAIO_DATA_DIR: ${{ runner.temp }}/cache/ensaio/
+          # Don't spam Zenodo from CI
+          ENSAIO_DATA_FROM_GITHUB: true
 
       # Store the docs as a build artifact so we can deploy it later
       - name: Upload HTML documentation as an artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,11 @@ jobs:
 
       - name: Run the tests
         run: make test
+        env:
+          # Define directory where sample data will be stored
+          ENSAIO_DATA_DIR: ${{ runner.temp }}/cache/ensaio/
+          # Don't spam Zenodo from CI
+          ENSAIO_DATA_FROM_GITHUB: true
 
       - name: Rename the coverage artifact
         run: mv .coverage .coverage.${{ matrix.os }}_${{ matrix.python }}_${{ matrix.dependencies }}


### PR DESCRIPTION
Fix the caching of Ensaio data (was missing setting the Ensaio cache folder to a known location), enable it on the test workflow, and fetch data from GitHub to avoid spamming Zenodo from CI.