### PR TITLE
Add the Zenodo DOI for all versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Part of the <a href="https://www.fatiando.org"><strong>Fatiando a Terra</strong>
 <a href="https://pypi.python.org/pypi/magali"><img src="http://img.shields.io/pypi/v/magali.svg?style=flat-square" alt="Latest version on PyPI"></a>
 <a href="https://github.com/conda-forge/magali-feedstock"><img src="https://img.shields.io/conda/vn/conda-forge/magali.svg?style=flat-square" alt="Latest version on conda-forge"></a>
 <a href="https://pypi.python.org/pypi/magali"><img src="https://img.shields.io/pypi/pyversions/magali.svg?style=flat-square" alt="Compatible Python versions."></a>
+<a href="https://doi.org/10.5281/zenodo.15535894"><img src="https://img.shields.io/badge/doi-10.5281%2Fzenodo.15535894-blue.svg?style=flat-square" alt="Digital Object Identifier for the Zenodo archive"/></a>
 </p>
 
 ## About

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -7,4 +7,4 @@ This is research software **made by scientists**. Citations help us justify the
 effort that goes into building and maintaining this project.
 
 If you used it in your research, please consider citing the latest Zenodo
-archive: https://doi.org/10.5281/zenodo.10808934
+archive: https://doi.org/10.5281/zenodo.15535894


### PR DESCRIPTION
Add it to a README badge and to the citing page of the docs. This doi was generated now that we have a publication of the placeholder version of Magali.

