### PR TITLE
Fix missing permissions when publishing docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -131,6 +131,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     if: github.event_name == 'release' || github.event_name == 'push'
 
     steps:


### PR DESCRIPTION
The `publish` job was missing the writing permissions it needed to push docs to GitHub Pages. Add them back.

