### PR TITLE
Actually fix missing permission in docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -158,9 +158,10 @@ jobs:
           path: deploy
           # Download the entire history
           fetch-depth: 0
-          # The GitHub token is preserved by default but this job doesn't need
-          # to be able to push to GitHub.
-          persist-credentials: false
+          # We need to explicitly preserve the credentials for the GitHub token
+          # on this branch so we can push to it.
+          persist-credentials: true
+
 
       - name: Push the built HTML to gh-pages
         run: |


### PR DESCRIPTION
The fix in #97 was not enough. We were also not preserving the push permissions for the gh-pages branch.