### PR TITLE
Use numba to calculate the linear Jacobian matrix

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -42,18 +42,20 @@ There are different ways to install magali:
 Which Python?
 -------------
 
-You'll need **Python >= 3.7**.
+You'll need **Python >= 3.9**.
 See :ref:`python-versions` if you require support for older versions.
 
 Dependencies
 ------------
 
 These required dependencies should be installed automatically when you install
-magali with ``pip`` or ``conda``:
+Magali with ``pip`` or ``conda``:
 
-* `numpy <http://www.numpy.org/>`__
-* `xarray <https://xarray.dev/>`__
+* `numpy <https://www.numpy.org/>`__
+* `scipy <https://scipy.org/>`__
+* `numba <https://numba.pydata.org/>`__
 * `scikit-image <https://scikit-image.org/>`__
+* `xarray <https://xarray.dev/>`__
 * `harmonica <https://www.fatiando.org/harmonica/>`__
 * `verde <https://www.fatiando.org/verde/>`__
 * `choclo <https://www.fatiando.org/choclo/>`__

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   # Run
   - numpy
   - scipy
+  - numba
   - scikit-image
   - xarray
   - harmonica

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,12 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.23",
     "scipy>=1.9",
+    "numba>=0.58",
     "scikit-image>=0.20",
     "xarray>=2022.6.0",
     "harmonica>=0.7",
     "verde>=1.8.1",
     "choclo>=0.2.0",
-    "matplotlib",
 ]
 
 [project.urls]

--- a/test/test_inversion.py
+++ b/test/test_inversion.py
@@ -12,60 +12,65 @@ import harmonica as hm
 import numpy as np
 import verde as vd
 
-from magali._inversion import MagneticMomentBz
-from magali._synthetic import dipole_bz_grid, random_directions
+from magali._inversion import MagneticMomentBz, _jacobian
+from magali._synthetic import dipole_bz
 
 
-def test_MagneticMomentBz():
-    sensor_sample_distance = 5.0  # µm
-    region = [0, 1000, 0, 1000]  # µm
-    spacing = 2  # µm
-
+def test_linear_magnetic_moment_bz_inversion():
+    "Check that the inversion recovers a known direction."
+    dipole_coordinates = (500, 500, -15)
     true_inclination = 30
     true_declination = 40
-    true_dispersion_angle = 5
-
+    true_intensity = 5e-11
+    true_moment = hm.magnetic_angles_to_vec(
+        inclination=true_inclination,
+        declination=true_declination,
+        intensity=true_intensity,
+    )
     coordinates = vd.grid_coordinates(
-        region=region,  # µm
-        spacing=spacing,  # µm
-        extra_coords=sensor_sample_distance,
+        region=[0, 100, 0, 100],
+        spacing=1,
+        extra_coords=5,
     )
-
-    size = 1
-
-    directions_inclination, directions_declination = random_directions(
-        true_inclination,
-        true_declination,
-        true_dispersion_angle,
-        size=size,
-        random_state=5,
-    )
-
-    dipole_coordinates = (500, 500, -15)
-
-    dipole_moment = hm.magnetic_angles_to_vec(
-        inclination=directions_inclination,
-        declination=directions_declination,
-        intensity=5e-11,
-    )
-
-    data = dipole_bz_grid(
-        region, spacing, sensor_sample_distance, dipole_coordinates, dipole_moment
-    )
-
-    data.plot.pcolormesh(cmap="seismic", vmin=-5000, vmax=5000)
-
+    data = dipole_bz(coordinates, dipole_coordinates, true_moment)
     model = MagneticMomentBz(dipole_coordinates)
-
     # Test initalization
     assert model.location == dipole_coordinates
     assert model.dipole_moment_ is None
-
+    # Run the inversion
     model.fit(coordinates, data)
-    dipole_moment = np.array(
-        [dipole_moment[0][0], dipole_moment[1][0], dipole_moment[2][0]]
-    )
-
     # Assert estimated moment is close to true moment
     assert model.dipole_moment_ is not None
-    np.testing.assert_allclose(model.dipole_moment_, dipole_moment, rtol=1e2)
+    np.testing.assert_allclose(model.dipole_moment_, true_moment)
+    # This fails because of a bug in the Harmonica function. Uncomment once
+    # 0.7.1 is out with a bug fix.
+    # intensity, inclination, declination = hm.magnetic_vec_to_angles(*model.dipole_moment_)
+    # np.testing.assert_allclose(intensity, true_intensity)
+    # np.testing.assert_allclose(declination, true_declination)
+    # np.testing.assert_allclose(inclination, true_inclination)
+
+
+def test_linear_magnetic_moment_gz_jacobian():
+    "Make sure the non-jitted Jacobian calculation is correct"
+    dipole_coordinates = (500, 500, -15)
+    true_inclination = 30
+    true_declination = 40
+    true_intensity = 5e-11
+    true_moment = hm.magnetic_angles_to_vec(
+        inclination=true_inclination,
+        declination=true_declination,
+        intensity=true_intensity,
+    )
+    coordinates = vd.grid_coordinates(
+        region=[0, 100, 0, 100],
+        spacing=2,
+        extra_coords=5,
+    )
+    data = dipole_bz(coordinates, dipole_coordinates, true_moment).ravel()
+    # Convert to meters for the Jacobian calculation
+    coordinates = tuple(c.ravel() * 1e-6 for c in coordinates)
+    dipole_coordinates = tuple(c * 1e-6 for c in dipole_coordinates)
+    jacobian = np.empty((coordinates[0].size, 3))
+    _jacobian(*coordinates, *dipole_coordinates, jacobian)
+    data_predicted = jacobian @ true_moment * 1e9
+    np.testing.assert_allclose(data_predicted, data)


### PR DESCRIPTION
Accelerate the Jacobian by jit-compiling with numba. Also start returning the Jacobian in nT instead of T so we don't need to convert the data units. Refactor the tests to avoid doing unnecessary things like plotting and generating random directions. Includes a test for the non-jit-compiled Jacobian as well using a simple forward modeling comparison to make sure all the code is covered by the tests.

**Relevant issues/PRs:** Fixes #81 
