### PR TITLE
Add baseline Makefile target for pytest-mpl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ build:
 install:
 	python -m pip install --no-deps --editable .
 
+baseline:
+	pytest --mpl-generate-path=test/baseline
+
 test:
 	pytest --cov-report=term-missing --cov --doctest-modules --verbose --mpl test src/$(PROJECT)
 


### PR DESCRIPTION
This PR adds a `baseline` target to the `Makefile` to streamline the generation of image baseline files for `pytest-mpl` visual tests.